### PR TITLE
feat: 🎸 add prefix calculating functions and expose metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ This data comprises of ip address count, max and used, for subnets, as well as a
 ```
 aws_subnet_exporter_available_ips
 aws_subnet_exporter_available_prefixes Available prefixes in subnets
-aws_subnet_exporter_max_ips Max host IPs in subnet
 aws_subnet_exporter_used_prefixes Used prefixes in subnets
 aws_subnet_exporter_max_ips Max host IPs in subnet
 ```

--- a/README.md
+++ b/README.md
@@ -1,20 +1,19 @@
 # AWS subnet exporter
-Fetch AWS subnet available IP count and expose it as Prometheus metrics. Why? Because AWS does not expose these in CloudWatch and you don't want to run out of available IP's in your subnets.
+
+Fetch AWS subnet data and expose it as Prometheus metrics. Why? Because AWS does not expose these in CloudWatch and you don't want to run out of available IP's in your subnets.
+
+This data comprises of ip address count, max and used, for subnets, as well as available contiguous subnet prefixes availables - this is especially important for our EKS nodes.
+
+[This video](https://www.youtube.com/watch?v=RBE3yk2UlYA) is a great explainer for how CNI works and why its important to us.
 
 ## Metrics exported
+
 ```
-# Curl metrics example
-curl http://localhost:8080/metrics
-
-# HELP aws_subnet_exporter_available_ips Available IPs in subnets
-# TYPE aws_subnet_exporter_available_ips gauge
-aws_subnet_exporter_available_ips{az="eu-west-1a",cidrblock="10.103.0.0/28",name="eks_clu_eu-west-1a",subnetid="subnet-XXX",vpcid="vpc-YYY"} 10
-...
-
-# HELP aws_subnet_exporter_max_ips Max host IPs in subnet
-# TYPE aws_subnet_exporter_max_ips gauge
-aws_subnet_exporter_max_ips{az="eu-west-1a",cidrblock="10.103.0.0/28",name="eks_clu_eu-west-1a",subnetid="subnet-XXX",vpcid="vpc-YYY"} 14
-...
+aws_subnet_exporter_available_ips
+aws_subnet_exporter_available_prefixes Available prefixes in subnets
+aws_subnet_exporter_max_ips Max host IPs in subnet
+aws_subnet_exporter_used_prefixes Used prefixes in subnets
+aws_subnet_exporter_max_ips Max host IPs in subnet
 ```
 
 ## Assumptions
@@ -27,7 +26,7 @@ You require this policy to your user/role (use roles for best practice) in order
     "Version": "2012-10-17",
     "Statement": [
         {
-            "Sid": "VisualEditor0",
+            "Sid": "some-sid",
             "Effect": "Allow",
             "Action": "ec2:DescribeSubnets",
             "Resource": "*"
@@ -36,17 +35,24 @@ You require this policy to your user/role (use roles for best practice) in order
 }
 ```
 
-## Running
-You have to provide an AWS context and I will not cover how to do this here.
+## Testing locally
+
+Go run directly:
+
+- Set your AWS creds
 
 ```bash
-docker run -p 8080:8080 -e AWS_ACCESS_KEY_ID=xyz -e AWS_SECRET_ACCESS_KEY=aaa ghcr.io/wcarlsen/aws-subnet-exporter:latest ./aws-subnet-exporter --port="8080" --region="eu-west-1" --filter="*" --period="60" --debug
+go run cmd/aws-subnet-exporter/main.go
 ```
 
-## Helm install
-For installing the exporter using helm. Do the following.
-```bash
-helm repo add aws-subnet-exporter https://wcarlsen.github.io/aws-subnet-exporter/
-helm repo update
-helm install --generate-name aws-subnet-exporter/aws-subnet-exporter
+This will launch with default params set (all subnets for region and current account)
+
+and then check your metrics outpur
+
 ```
+curl localhost:8080/metrics
+```
+
+## Helm
+
+Helm charts for the exporter are published in [cloud-platform-helm-charts](https://github.com/ministryofjustice/cloud-platform-helm-charts/tree/main/aws-subnet-exporter)

--- a/cmd/aws-subnet-exporter/main.go
+++ b/cmd/aws-subnet-exporter/main.go
@@ -5,10 +5,10 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/ministryofjustice/aws-subnet-exporter/pkg/aws"
+	prom "github.com/ministryofjustice/aws-subnet-exporter/pkg/prometheus"
+	"github.com/ministryofjustice/aws-subnet-exporter/pkg/utils"
 	log "github.com/sirupsen/logrus"
-	"github.com/wcarlsen/aws-subnet-exporter/pkg/aws"
-	prom "github.com/wcarlsen/aws-subnet-exporter/pkg/prometheus"
-	"github.com/wcarlsen/aws-subnet-exporter/pkg/utils"
 )
 
 const (
@@ -19,7 +19,7 @@ const (
 
 var (
 	port   = flag.String("port", "8080", "The port to listen on for HTTP requests.")
-	region = flag.String("region", "eu-west-1", "AWS region")
+	region = flag.String("region", "eu-west-2", "AWS region")
 	filter = flag.String("filter", "*", "Filter subnets by tag regex when calling AWS (assumes tag key is Name")
 	period = flag.Duration("period", 60*time.Second, "Period for calling AWS in seconds")
 	debug  = flag.Bool("debug", false, "Enable debug logging")
@@ -52,6 +52,8 @@ func main() {
 			for _, v := range subnets {
 				prom.AvailableIPs.WithLabelValues(v.VPCID, v.SubnetID, v.CIDRBlock, v.AZ, v.Name).Set(v.AvailableIPs)
 				prom.MaxIPs.WithLabelValues(v.VPCID, v.SubnetID, v.CIDRBlock, v.AZ, v.Name).Set(v.MaxIPs)
+				prom.UsedPrefixes.WithLabelValues(v.VPCID, v.SubnetID, v.CIDRBlock, v.AZ, v.Name).Set(float64(v.UsedPrefixes))
+				prom.AvailablePrefixes.WithLabelValues(v.VPCID, v.SubnetID, v.CIDRBlock, v.AZ, v.Name).Set(float64(len(v.AvailablePrefixes)))
 			}
 
 			select {

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
-module github.com/wcarlsen/aws-subnet-exporter
+module github.com/ministryofjustice/aws-subnet-exporter
 
 go 1.19
 
 require (
-	github.com/apparentlymart/go-cidr v1.1.0
+	github.com/aws/aws-sdk-go-v2 v1.17.3
 	github.com/aws/aws-sdk-go-v2/config v1.18.8
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.78.0
 	github.com/pkg/errors v0.9.1
@@ -12,7 +12,6 @@ require (
 )
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.17.3 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.13.8 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.27 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,6 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
-github.com/apparentlymart/go-cidr v1.1.0 h1:2mAhrMoF+nhXqxTzSZMUzDHkLjmIHC+Zzn4tdgBZjnU=
-github.com/apparentlymart/go-cidr v1.1.0/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=
 github.com/aws/aws-sdk-go-v2 v1.17.3 h1:shN7NlnVzvDUgPQ+1rLMSxY8OWRNDRYtiqe0p/PgrhY=
 github.com/aws/aws-sdk-go-v2 v1.17.3/go.mod h1:uzbQtefpm44goOPmdKyAlXSNcwlRgF3ePWVW6EtJvvw=
 github.com/aws/aws-sdk-go-v2/config v1.18.8 h1:lDpy0WM8AHsywOnVrOHaSMfpaiV2igOw8D7svkFkXVA=

--- a/pkg/aws/subnets.go
+++ b/pkg/aws/subnets.go
@@ -2,79 +2,86 @@ package aws
 
 import (
 	"context"
-	"net"
 
-	"github.com/apparentlymart/go-cidr/cidr"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/ministryofjustice/aws-subnet-exporter/pkg/utils"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
-const (
-	errCannotParseCIDRBlock    = "cannot parse CIDR block"
-	errCannotDescribeSubnets   = "cannot describe subnets"
-	errUnableToCalculateMaxIPs = "unable to calculate MaxIPs from at least one CIDR block"
-)
-
 type Subnet struct {
-	Name         string
-	SubnetID     string
-	VPCID        string
-	CIDRBlock    string
-	AZ           string
-	AvailableIPs float64
-	MaxIPs       float64
+	Name         		string
+	SubnetID     		string
+	VPCID        		string
+	CIDRBlock    		string
+	AZ           		string
+	AvailableIPs 		float64
+	MaxIPs       		float64
+	UsedPrefixes 		int
+	AvailablePrefixes 	[]string
 }
 
-// Get subnets
 func GetSubnets(client *ec2.Client, filter string) ([]Subnet, error) {
-	log.Debug("Describing subnets")
-	nameIdentifier := "tag:Name"
-	resp, err := client.DescribeSubnets(context.TODO(), &ec2.DescribeSubnetsInput{
-		Filters: []types.Filter{{
-			Name:   &nameIdentifier,
-			Values: []string{filter},
-		}},
-	})
-	if err != nil {
-		log.Debug("Failed to describe subnets")
-		return nil, errors.Wrap(err, errCannotDescribeSubnets)
-	}
+    log.Debug("Describing subnets")
+    nameIdentifier := "tag:Name"
+    resp, err := client.DescribeSubnets(context.TODO(), &ec2.DescribeSubnetsInput{
+        Filters: []types.Filter{{
+            Name:   &nameIdentifier,
+            Values: []string{filter},
+        }},
+    })
+    if err != nil {
+        log.Debug("Failed to describe subnets")
+        return nil, errors.Wrap(err, "cannot describe subnets")
+    }
 
-	var subnets []Subnet
-	for _, v := range resp.Subnets {
-		subnet := Subnet{
-			Name:         getNameFromTags(v.Tags),
-			SubnetID:     *v.SubnetId,
-			VPCID:        *v.VpcId,
-			CIDRBlock:    *v.CidrBlock,
-			AZ:           *v.AvailabilityZone,
-			AvailableIPs: float64(*v.AvailableIpAddressCount),
-		}
-		err := subnet.getMaxIPs()
-		if err != nil {
-			return nil, errors.Wrap(err, errUnableToCalculateMaxIPs)
-		}
-		subnets = append(subnets, subnet)
-	}
-	return subnets, nil
+    var subnets []Subnet
+    for _, v := range resp.Subnets {
+        subnet, err := processSubnet(client, v)
+        if err != nil {
+            return nil, err
+        }
+        subnets = append(subnets, subnet)
+    }
+    return subnets, nil
 }
 
-func (s *Subnet) getMaxIPs() error {
-	_, IPNet, err := net.ParseCIDR(s.CIDRBlock)
-	if err != nil {
-		return errors.Wrap(err, errCannotParseCIDRBlock)
-	}
-	s.MaxIPs = float64(cidr.AddressCount(IPNet) - 2) // because we cannot use first and last
-	return nil
+func processSubnet(client *ec2.Client, v types.Subnet) (Subnet, error) {
+    log.Debugf("Processing subnet: %s", *v.SubnetId)
+    subnet := Subnet{
+        Name:         utils.GetNameFromTags(v.Tags),
+        SubnetID:     *v.SubnetId,
+        VPCID:        *v.VpcId,
+        CIDRBlock:    *v.CidrBlock,
+        AZ:           *v.AvailabilityZone,
+        AvailableIPs: float64(*v.AvailableIpAddressCount),
+    }
+
+    maxIPs, err := utils.CalculateMaxIPs(subnet.CIDRBlock)
+    if err != nil {
+        return Subnet{}, errors.Wrap(err, "unable to calculate MaxIPs from at least one CIDR block")
+    }
+    subnet.MaxIPs = maxIPs
+
+    details, err := utils.GetSubnetDetails(context.TODO(), client, subnet.SubnetID)
+    if err != nil {
+        return Subnet{}, errors.Wrap(err, "unable to get subnet details")
+    }
+
+    prefixesInUse, ipsInUse, err := utils.GetIPsAndPrefixes(context.TODO(), client, subnet.SubnetID, details)
+    if err != nil {
+        return Subnet{}, errors.Wrap(err, "unable to get IPs and prefixes")
+    }
+
+    utils.CalculatePrefixes(details, prefixesInUse, ipsInUse)
+
+    subnet.UsedPrefixes = details.PrefixesInUse
+    subnet.AvailablePrefixes = details.AvailablePrefixes
+
+    return subnet, nil
 }
 
-func getNameFromTags(tags []types.Tag) string {
-	for _, v := range tags {
-		if *v.Key == "Name" {
-			return *v.Value
-		}
-	}
-	return "UNKNOWN"
-}
+
+
+

--- a/pkg/aws/subnets.go
+++ b/pkg/aws/subnets.go
@@ -11,73 +11,78 @@ import (
 )
 
 type Subnet struct {
-	Name         		string
-	SubnetID     		string
-	VPCID        		string
-	CIDRBlock    		string
-	AZ           		string
-	AvailableIPs 		float64
-	MaxIPs       		float64
-	UsedPrefixes 		int
-	AvailablePrefixes 	[]string
+	Name              string
+	SubnetID          string
+	VPCID             string
+	CIDRBlock         string
+	AZ                string
+	AvailableIPs      float64
+	MaxIPs            float64
+	UsedPrefixes      int
+	AvailablePrefixes []string
 }
 
 func GetSubnets(client *ec2.Client, filter string) ([]Subnet, error) {
-    log.Debug("Describing subnets")
-    nameIdentifier := "tag:Name"
-    resp, err := client.DescribeSubnets(context.TODO(), &ec2.DescribeSubnetsInput{
-        Filters: []types.Filter{{
-            Name:   &nameIdentifier,
-            Values: []string{filter},
-        }},
-    })
-    if err != nil {
-        log.Debug("Failed to describe subnets")
-        return nil, errors.Wrap(err, "cannot describe subnets")
-    }
+	log.Debug("Describing subnets")
+	nameIdentifier := "tag:Name"
+	resp, err := client.DescribeSubnets(context.TODO(), &ec2.DescribeSubnetsInput{
+		Filters: []types.Filter{{
+			Name:   &nameIdentifier,
+			Values: []string{filter},
+		}},
+	})
+	if err != nil {
+		log.Debug("Failed to describe subnets")
+		return nil, errors.Wrap(err, "cannot describe subnets")
+	}
 
-    var subnets []Subnet
-    for _, v := range resp.Subnets {
-        subnet, err := processSubnet(client, v)
-        if err != nil {
-            return nil, err
-        }
-        subnets = append(subnets, subnet)
-    }
-    return subnets, nil
+	var subnets []Subnet
+	for _, v := range resp.Subnets {
+		subnet, err := processSubnet(client, v)
+		if err != nil {
+			return nil, err
+		}
+		subnets = append(subnets, subnet)
+	}
+	return subnets, nil
 }
 
-func processSubnet(client *ec2.Client, v types.Subnet) (Subnet, error) {
-    log.Debugf("Processing subnet: %s", *v.SubnetId)
-    subnet := Subnet{
-        Name:         utils.GetNameFromTags(v.Tags),
-        SubnetID:     *v.SubnetId,
-        VPCID:        *v.VpcId,
-        CIDRBlock:    *v.CidrBlock,
-        AZ:           *v.AvailabilityZone,
-        AvailableIPs: float64(*v.AvailableIpAddressCount),
-    }
+func processSubnet(ec2Client *ec2.Client, v types.Subnet) (Subnet, error) {
+	log.Debugf("Processing subnet: %s", *v.SubnetId)
+	subnet := Subnet{
+		Name:         utils.GetNameFromTags(v.Tags),
+		SubnetID:     *v.SubnetId,
+		VPCID:        *v.VpcId,
+		CIDRBlock:    *v.CidrBlock,
+		AZ:           *v.AvailabilityZone,
+		AvailableIPs: float64(*v.AvailableIpAddressCount),
+	}
 
-    details, err := utils.GetSubnetDetails(context.TODO(), client, subnet.SubnetID)
-    if err != nil {
-        return Subnet{}, errors.Wrap(err, "unable to get subnet details")
-    }
+	describeSubnetsOutput := &ec2.DescribeSubnetsOutput{
+		Subnets: []types.Subnet{v},
+	}
 
-    subnet.MaxIPs = float64(details.TotalIPs)
+	details, err := utils.EnrichSubnetData(describeSubnetsOutput)
+	if err != nil {
+		return Subnet{}, errors.Wrap(err, "unable to get subnet details")
+	}
 
-    prefixesInUse, ipsInUse, err := utils.GetIPsAndPrefixes(context.TODO(), client, subnet.SubnetID, details)
-    if err != nil {
-        return Subnet{}, errors.Wrap(err, "unable to get IPs and prefixes")
-    }
+	subnet.MaxIPs = float64(details.TotalIPs)
 
-    utils.CalculatePrefixes(details, prefixesInUse, ipsInUse)
+	networkInterfacesOutput, err := utils.DescribeNetworkInterfacesBySubnetID(context.TODO(), ec2Client, *v.SubnetId)
+	if err != nil {
+		return Subnet{}, errors.Wrap(err, "unable to describe network interfaces")
+	}
+	
+	prefixesInUse, ipsInUse, err := utils.EnrichIPsAndPrefixes(networkInterfacesOutput, details)
+	if err != nil {
+		return Subnet{}, errors.Wrap(err, "unable to get IPs and prefixes")
+	}
 
-    subnet.UsedPrefixes = details.PrefixesInUse
-    subnet.AvailablePrefixes = details.AvailablePrefixes
+	utils.CalculatePrefixes(details, prefixesInUse, ipsInUse)
 
-    return subnet, nil
+	subnet.UsedPrefixes = details.PrefixesInUse
+	subnet.AvailablePrefixes = details.AvailablePrefixes
+
+	return subnet, nil
 }
-
-
-
-

--- a/pkg/aws/subnets.go
+++ b/pkg/aws/subnets.go
@@ -58,16 +58,12 @@ func processSubnet(client *ec2.Client, v types.Subnet) (Subnet, error) {
         AvailableIPs: float64(*v.AvailableIpAddressCount),
     }
 
-    maxIPs, err := utils.CalculateMaxIPs(subnet.CIDRBlock)
-    if err != nil {
-        return Subnet{}, errors.Wrap(err, "unable to calculate MaxIPs from at least one CIDR block")
-    }
-    subnet.MaxIPs = maxIPs
-
     details, err := utils.GetSubnetDetails(context.TODO(), client, subnet.SubnetID)
     if err != nil {
         return Subnet{}, errors.Wrap(err, "unable to get subnet details")
     }
+
+    subnet.MaxIPs = float64(details.TotalIPs)
 
     prefixesInUse, ipsInUse, err := utils.GetIPsAndPrefixes(context.TODO(), client, subnet.SubnetID, details)
     if err != nil {

--- a/pkg/prometheus/metrics.go
+++ b/pkg/prometheus/metrics.go
@@ -22,10 +22,25 @@ var (
 		Name: prefix + "max_ips",
 		Help: "Max host IPs in subnet",
 	}, labels)
+
+	// Prometheus gauge vector for used prefixes in subnets
+	UsedPrefixes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: prefix + "used_prefixes",
+		Help: "Used prefixes in subnets",
+	}, labels)
+
+	// Prometheus gauge vector for available prefixes in subnets
+	AvailablePrefixes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: prefix + "available_prefixes",
+		Help: "Available prefixes in subnets",
+	}, labels)
+
 )
 
 // Prometheus register metrics
 func RegisterMetrics() {
 	prometheus.MustRegister(AvailableIPs)
 	prometheus.MustRegister(MaxIPs)
+	prometheus.MustRegister(UsedPrefixes)
+	prometheus.MustRegister(AvailablePrefixes)
 }

--- a/pkg/utils/helpers.go
+++ b/pkg/utils/helpers.go
@@ -1,0 +1,186 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/pkg/errors"
+)
+
+type SubnetDetails struct {
+    SubnetCIDR          string
+    SubnetMask          int
+    TotalIPs            int
+    CIDRFirstDigit      int
+    CIDRSecondDigit     int
+    CIDRThirdDigit      int
+    CIDRLastDigit       int
+    InterfacesInUse     int
+    AllocatedIPs        int
+    FreeIPs             int
+    MaxPrefixes         int
+    PrefixesInUse       int
+    AvailablePrefixes   []string
+}
+
+func CalculateMaxIPs(cidr string) (float64, error) {
+    _, IPNet, err := net.ParseCIDR(cidr)
+    if err != nil {
+        return 0, errors.Wrap(err, "cannot parse CIDR block")
+    }
+
+    ones, bits := IPNet.Mask.Size()
+    totalIPs := math.Pow(2, float64(bits-ones))
+    return totalIPs - 2, nil
+}
+
+func splitCIDR(cidr string) (string, int, error) {
+    parts := strings.Split(cidr, "/")
+    if len(parts) != 2 {
+        return "", 0, fmt.Errorf("invalid CIDR format: %s", cidr)
+    }
+    mask, err := strconv.Atoi(parts[1])
+    if err != nil {
+        return "", 0, fmt.Errorf("invalid subnet mask: %w", err)
+    }
+    return parts[0], mask, nil
+}
+
+func splitIP(ip string) ([]int, error) {
+    parts := strings.Split(ip, ".")
+    if len(parts) != 4 {
+        return nil, fmt.Errorf("invalid IP format: %s", ip)
+    }
+    result := make([]int, 4)
+    for i, part := range parts {
+        val, err := strconv.Atoi(part)
+        if err != nil {
+            return nil, fmt.Errorf("invalid IP part: %w", err)
+        }
+        result[i] = val
+    }
+    return result, nil
+}
+
+func GetSubnetDetails(ctx context.Context, ec2Client *ec2.Client, subnetID string) (*SubnetDetails, error) {
+    output, err := ec2Client.DescribeSubnets(ctx, &ec2.DescribeSubnetsInput{
+        SubnetIds: []string{subnetID},
+    })
+    if err != nil {
+        return nil, fmt.Errorf("failed to describe subnets: %w", err)
+    }
+
+    subnetCIDR := aws.ToString(output.Subnets[0].CidrBlock)
+    ip, mask, err := splitCIDR(subnetCIDR)
+    if err != nil {
+        return nil, err
+    }
+
+    ipParts, err := splitIP(ip)
+    if err != nil {
+        return nil, err
+    }
+
+    totalIPs := int(math.Pow(2, float64(32-mask)))
+
+    return &SubnetDetails{
+        SubnetCIDR:      subnetCIDR,
+        SubnetMask:      mask,
+        TotalIPs:        totalIPs,
+        CIDRFirstDigit:  ipParts[0],
+        CIDRSecondDigit: ipParts[1],
+        CIDRThirdDigit:  ipParts[2],
+        CIDRLastDigit:   ipParts[3],
+    }, nil
+}
+
+func GetIPsAndPrefixes(ctx context.Context, ec2Client *ec2.Client, subnetID string, details *SubnetDetails) (map[string]bool, map[string]bool, error) {
+    output, err := ec2Client.DescribeNetworkInterfaces(ctx, &ec2.DescribeNetworkInterfacesInput{
+        Filters: []types.Filter{
+            {
+                Name:   aws.String("subnet-id"),
+                Values: []string{subnetID},
+            },
+        },
+    })
+    if err != nil {
+        return nil, nil, fmt.Errorf("failed to describe network interfaces: %w", err)
+    }
+
+    prefixesInUse := make(map[string]bool)
+    ipsInUse := make(map[string]bool)
+    ipsPerPrefix := 16
+
+    for _, iface := range output.NetworkInterfaces {
+        details.InterfacesInUse++
+        for _, privateIP := range iface.PrivateIpAddresses {
+            ipsInUse[aws.ToString(privateIP.PrivateIpAddress)] = true
+        }
+        for _, prefix := range iface.Ipv4Prefixes {
+            prefixesInUse[aws.ToString(prefix.Ipv4Prefix)] = true
+        }
+    }
+
+    details.PrefixesInUse = len(prefixesInUse)
+    details.AllocatedIPs = (details.PrefixesInUse * ipsPerPrefix) + len(ipsInUse) + 5
+    details.MaxPrefixes = details.TotalIPs / ipsPerPrefix
+
+    return prefixesInUse, ipsInUse, nil
+}
+
+func CalculatePrefixes(details *SubnetDetails, prefixesInUse map[string]bool, ipsInUse map[string]bool) {
+    ipsPerPrefix := 16
+    availablePrefixes := []string{}
+
+    baseFirstDigit := details.CIDRFirstDigit
+    baseSecondDigit := details.CIDRSecondDigit
+    baseThirdDigit := details.CIDRThirdDigit
+    baseLastDigit := details.CIDRLastDigit
+
+    for i := 1; i <= details.MaxPrefixes; i++ {
+
+        baseLastDigit += ipsPerPrefix
+        if baseLastDigit > 255 {
+            baseThirdDigit++
+            baseLastDigit = 0
+        }
+
+        prefix := fmt.Sprintf("%d.%d.%d.%d/%d", baseFirstDigit, baseSecondDigit, baseThirdDigit, baseLastDigit, 28)
+
+        if prefixesInUse[prefix] {
+            continue
+        }
+
+        isAvailable := true
+        for j := 0; j < ipsPerPrefix; j++ {
+            ip := fmt.Sprintf("%d.%d.%d.%d", baseFirstDigit, baseSecondDigit, baseThirdDigit, baseLastDigit+j)
+            if ipsInUse[ip] {
+                isAvailable = false
+                break
+            }
+        }
+
+        if isAvailable {
+            availablePrefixes = append(availablePrefixes, prefix)
+        }
+    }
+
+    details.AvailablePrefixes = availablePrefixes
+    details.FreeIPs = details.TotalIPs - details.AllocatedIPs
+}
+
+func GetNameFromTags(tags []types.Tag) string {
+	for _, v := range tags {
+		if *v.Key == "Name" {
+			return *v.Value
+		}
+	}
+	return "No name tag found"
+}

--- a/pkg/utils/helpers_test.go
+++ b/pkg/utils/helpers_test.go
@@ -1,0 +1,348 @@
+package utils
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+func TestCalculateMaxIPs(t *testing.T) {
+	tests := []struct {
+		name      string
+		cidr      string
+		want      float64
+		expectErr bool
+	}{
+		{
+			name:      "Valid /24 CIDR",
+			cidr:      "172.16.0.0/24",
+			want:      254,
+			expectErr: false,
+		},
+		{
+			name:      "Valid /16 CIDR",
+			cidr:      "172.16.0.0/16",
+			want:      65534,
+			expectErr: false,
+		},
+		{
+			name:      "Valid /30 CIDR",
+			cidr:      "172.16.0.0/30",
+			want:      2,
+			expectErr: false,
+		},
+		{
+			name:      "Valid /32 CIDR (single IP)",
+			cidr:      "192.168.1.1/32",
+			want:      -1,
+			expectErr: false,
+		},
+		{
+			name:      "Invalid CIDR format",
+			cidr:      "172.16.0.0",
+			want:      0,
+			expectErr: true,
+		},
+		{
+			name:      "Invalid IP in CIDR",
+			cidr:      "999.999.999.999/24",
+			want:      0,
+			expectErr: true,
+		},
+		{
+			name:      "Empty string",
+			cidr:      "",
+			want:      0,
+			expectErr: true,
+		},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CalculateMaxIPs(tt.cidr)
+			if (err != nil) != tt.expectErr {
+				t.Errorf("CalculateMaxIPs() error = %v, expectErr %v", err, tt.expectErr)
+				return
+			}
+			if !tt.expectErr && got != tt.want {
+				t.Errorf("CalculateMaxIPs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSplitCIDR(t *testing.T) {
+	tests := []struct {
+		name      string
+		cidr      string
+		wantIP    string
+		wantMask  int
+		expectErr bool
+	}{
+		{
+			name:      "Valid CIDR",
+			cidr:      "172.16.0.0/24",
+			wantIP:    "172.16.0.0",
+			wantMask:  24,
+			expectErr: false,
+		},
+		{
+			name:      "Valid CIDR with different mask",
+			cidr:      "172.16.0.0/16",
+			wantIP:    "172.16.0.0",
+			wantMask: 16,
+			expectErr: false,
+		},
+		{
+			name:      "Invalid CIDR format",
+			cidr:      "172.16.0.0",
+			wantIP:    "",
+			wantMask:  0,
+			expectErr: true,
+		},
+		{
+			name:      "Invalid CIDR with non-numeric mask",
+			cidr:      "172.16.0.0/ab",
+			wantIP:    "",
+			wantMask:  0,
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotIP, gotMask, err := splitCIDR(tt.cidr)
+			if (err != nil) != tt.expectErr {
+				t.Errorf("splitCIDR() error = %v, expectErr %v", err, tt.expectErr)
+				return
+			}
+			if !tt.expectErr && (gotIP != tt.wantIP || gotMask != tt.wantMask) {
+				t.Errorf("splitCIDR() = %v/%v, want %v/%v", gotIP, gotMask, tt.wantIP, tt.wantMask)
+			}
+		})
+	}
+}
+
+func TestSplitIP(t *testing.T) {
+	tests := []struct {
+		name      string
+		ip        string
+		want      []int
+		expectErr bool
+	}{
+		{
+			name:      "Valid IP",
+			ip:        "172.16.0.125",
+			want:      []int{172, 16, 0, 125},
+			expectErr: false,
+		},
+		{
+			name:	  "Invalid IP format short",
+			ip:        "172.16.0",
+			want:      nil,
+			expectErr: true,
+		},
+		{
+			name:      "Invalid IP format long",
+			ip:        "172.16.0.1.1",
+			want:      nil,
+			expectErr: true,
+		},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := splitIP(tt.ip)
+			if (err != nil) != tt.expectErr {
+				t.Errorf("splitIP() error = %v, expectErr %v", err, tt.expectErr)
+				return
+			}
+			if !tt.expectErr && !equalSlices(got, tt.want) {
+				t.Errorf("splitIP() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// helper function for comparing ip slices
+func equalSlices(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestEnrichSubnetData(t *testing.T) {
+    tests := []struct {
+        name      string
+        input     *ec2.DescribeSubnetsOutput
+        want      *SubnetDetails
+        expectErr bool
+    }{
+        {
+            name: "Valid subnet data",
+            input: &ec2.DescribeSubnetsOutput{
+                Subnets: []types.Subnet{
+                    {
+                        CidrBlock: aws.String("172.16.1.0/24"),
+                    },
+                },
+            },
+            want: &SubnetDetails{
+                SubnetCIDR:      "172.16.1.0/24",
+                SubnetMask:      24,
+                TotalIPs:        256,
+                CIDRFirstDigit:  172,
+                CIDRSecondDigit: 16,
+                CIDRThirdDigit:  1,
+                CIDRLastDigit:   0,
+            },
+            expectErr: false,
+        },
+        {
+            name: "Empty subnets",
+            input: &ec2.DescribeSubnetsOutput{
+                Subnets: []types.Subnet{},
+            },
+            want:      nil,
+            expectErr: true,
+        },
+        {
+            name: "Invalid CIDR in subnet",
+            input: &ec2.DescribeSubnetsOutput{
+                Subnets: []types.Subnet{
+                    {
+                        CidrBlock: aws.String("172.16.1.0"),
+                    },
+                },
+            },
+            want:      nil,
+            expectErr: true,
+        },
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            got, err := EnrichSubnetData(tt.input)
+            if (err != nil) != tt.expectErr {
+                t.Errorf("EnrichSubnetData() error = %v, expectErr %v", err, tt.expectErr)
+                return
+            }
+            if !tt.expectErr && got != nil && tt.want != nil {
+                if got.SubnetCIDR != tt.want.SubnetCIDR ||
+                    got.SubnetMask != tt.want.SubnetMask ||
+                    got.TotalIPs != tt.want.TotalIPs ||
+                    got.CIDRFirstDigit != tt.want.CIDRFirstDigit ||
+                    got.CIDRSecondDigit != tt.want.CIDRSecondDigit ||
+                    got.CIDRThirdDigit != tt.want.CIDRThirdDigit ||
+                    got.CIDRLastDigit != tt.want.CIDRLastDigit {
+                    t.Errorf("EnrichSubnetData() = %+v, want %+v", got, tt.want)
+					// output got and tt.want for debugging
+					fmt.Printf("got: %+v\n", got)
+					fmt.Printf("want: %+v\n", tt.want)
+
+                }
+            }
+        })
+    }
+}
+
+func TestEnrichIPsAndPrefixes(t *testing.T) {
+    tests := []struct {
+        name         string
+        input        *ec2.DescribeNetworkInterfacesOutput
+        details      *SubnetDetails
+        wantIPs      map[string]bool
+        wantPrefixes map[string]bool
+        expectErr    bool
+    }{
+        {
+            name: "Valid network interfaces",
+            input: &ec2.DescribeNetworkInterfacesOutput{
+                NetworkInterfaces: []types.NetworkInterface{
+                    {
+						PrivateIpAddresses: []types.NetworkInterfacePrivateIpAddress{
+							{PrivateIpAddress: aws.String("172.16.1.125")},
+							{PrivateIpAddress: aws.String("172.16.1.126")},
+						},
+                        Ipv4Prefixes: []types.Ipv4PrefixSpecification{
+                            {Ipv4Prefix: aws.String("172.16.1.112/28")},
+                        },
+                    },
+                },
+            },
+            details: &SubnetDetails{
+                SubnetCIDR:      "172.16.1.0/24",
+                SubnetMask:      24,
+                TotalIPs:        256,
+                CIDRFirstDigit:  172,
+                CIDRSecondDigit: 16,
+                CIDRThirdDigit:  1,
+                CIDRLastDigit:   0,
+            },
+            wantIPs: map[string]bool{
+                "172.16.1.125": true,
+                "172.16.1.126": true,
+            },
+            wantPrefixes: map[string]bool{
+                "172.16.1.112/28": true,
+            },
+            expectErr: false,
+        },
+        {
+            name: "No network interfaces",
+            input: &ec2.DescribeNetworkInterfacesOutput{
+                NetworkInterfaces: []types.NetworkInterface{},
+            },
+            details: &SubnetDetails{
+                SubnetCIDR:      "172.16.1.0/24",
+                SubnetMask:      24,
+                TotalIPs:        256,
+                CIDRFirstDigit:  172,
+                CIDRSecondDigit: 16,
+                CIDRThirdDigit:  1,
+                CIDRLastDigit:   0,
+            },
+            wantIPs:      map[string]bool{},
+            wantPrefixes: map[string]bool{},
+            expectErr:    false,
+        },
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            gotPrefixes, gotIPs, err := EnrichIPsAndPrefixes(tt.input, tt.details)
+            if (err != nil) != tt.expectErr {
+                t.Errorf("EnrichIPsAndPrefixes() error = %v, expectErr %v", err, tt.expectErr)
+                return
+            }
+            if !mapsEqual(gotIPs, tt.wantIPs) {
+                t.Errorf("EnrichIPsAndPrefixes() gotIPs = %v, want %v", gotIPs, tt.wantIPs)
+            }
+            if !mapsEqual(gotPrefixes, tt.wantPrefixes) {
+                t.Errorf("EnrichIPsAndPrefixes() gotPrefixes = %v, want %v", gotPrefixes, tt.wantPrefixes)
+            }
+        })
+    }
+}
+
+// helper for comparing maps
+func mapsEqual(a, b map[string]bool) bool {
+    if len(a) != len(b) {
+        return false
+    }
+    for k, v := range a {
+        if b[k] != v {
+            return false
+        }
+    }
+    return true
+}


### PR DESCRIPTION
This PR enhances the functionality of aws-subnet-exporter by:

Adding CIDR prefix calculating functions and exposing metrics endpoints for querying used and available prefixes for VPC subnets.

Adding unit test coverage for new utility functions.

relates to ministryofjustice/cloud-platform#6550